### PR TITLE
Revert "Update index.yaml"

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,36 +2,6 @@ apiVersion: v1
 entries:
   longhorn:
   - apiVersion: v1
-    appVersion: v1.0.1-rc1
-    created: "2020-07-15T00:12:47.653014704Z"
-    description: Longhorn is a distributed block storage system for Kubernetes powered
-      by Rancher Labs.
-    digest: 36ae2df815d8ecd18cb744232290b33e3627d0a92e3e8a722340adfba5d6ae52
-    home: https://github.com/longhorn/longhorn
-    icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/horizontal/color/longhorn-horizontal-color.svg?sanitize=true
-    keywords:
-    - longhorn
-    - storage
-    - distributed
-    - block
-    - device
-    - iscsi
-    kubeVersion: '>=v1.14.0-r0'
-    maintainers:
-    - email: charts@rancher.com
-      name: rancher
-    name: longhorn
-    sources:
-    - https://github.com/longhorn/longhorn
-    - https://github.com/longhorn/longhorn-engine
-    - https://github.com/longhorn/longhorn-instance-manager
-    - https://github.com/longhorn/longhorn-manager
-    - https://github.com/longhorn/longhorn-ui
-    - https://github.com/longhorn/longhorn-tests
-    urls:
-    - https://github.com/longhorn/charts/releases/download/longhorn-1.0.1-rc1/longhorn-1.0.1-rc1.tgz
-    version: 1.0.1-rc1
-  - apiVersion: v1
     appVersion: v1.0.0
     created: "2020-07-09T22:48:59.417803565Z"
     description: Longhorn is a distributed block storage system for Kubernetes powered


### PR DESCRIPTION
This PR reverts commit 9583b8dd079ed9076aeb01db82fc79527ed40179.

This removes `v1.0.1-rc1` from the listing of releases for this repository for the reasons mentioned in #3.