### PR TITLE
StorageClass: add reclaimPolicy

### DIFF
--- a/charts/longhorn/questions.yml
+++ b/charts/longhorn/questions.yml
@@ -167,6 +167,13 @@ questions:
     type: boolean
     required: true
     label: Default Storage Class
+  - variable: persistence.reclaimPolicy
+    default: "Delete"
+    description: "Define reclaim policy (Retain or Delete)"
+    group: "Longhorn CSI Driver Settings"
+    type: string
+    required: true
+    label: Default Storage Class
   - variable: persistence.defaultClassReplicaCount
     description: "Set replica count for default StorageClass"
     group: "Longhorn CSI Driver Settings"

--- a/charts/longhorn/templates/storageclass.yaml
+++ b/charts/longhorn/templates/storageclass.yaml
@@ -7,6 +7,7 @@ metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
+reclaimPolicy: "{{ .Values.persistence.reclaimPolicy }}"
 parameters:
   numberOfReplicas: "{{ .Values.persistence.defaultClassReplicaCount }}"
   staleReplicaTimeout: "30"

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -24,6 +24,7 @@ service:
 persistence:
   defaultClass: true
   defaultClassReplicaCount: 3
+  reclaimPolicy: Delete
 
 csi:
   attacherImage: longhornio/csi-attacher


### PR DESCRIPTION
StorageClass lacks ability to define `retainPolicy` which is a pain in some sensible environments.
This PR solves it by adding a setting and maintaining the previous behavior as default (`Delete`)