### PR TITLE
Feature/recurring jobs

### DIFF
--- a/charts/longhorn/templates/storageclass.yaml
+++ b/charts/longhorn/templates/storageclass.yaml
@@ -11,4 +11,7 @@ parameters:
   numberOfReplicas: "{{ .Values.persistence.defaultClassReplicaCount }}"
   staleReplicaTimeout: "30"
   fromBackup: ""
+  {{ if .Values.persistence.recurringJobs  }}
+  recurringJobs: '{{ toJson .Values.persistence.recurringJobs }}'
+  {{ end }}
   baseImage: ""

--- a/charts/longhorn/templates/storageclass.yaml
+++ b/charts/longhorn/templates/storageclass.yaml
@@ -15,4 +15,3 @@ parameters:
   recurringJobs: '{{ toJson .Values.persistence.recurringJobs }}'
   {{ end }}
   baseImage: ""
-  

--- a/charts/longhorn/templates/storageclass.yaml
+++ b/charts/longhorn/templates/storageclass.yaml
@@ -15,3 +15,4 @@ parameters:
   recurringJobs: '{{ toJson .Values.persistence.recurringJobs }}'
   {{ end }}
   baseImage: ""
+  

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -24,6 +24,16 @@ service:
 persistence:
   defaultClass: true
   defaultClassReplicaCount: 3
+  recurringJobs:
+    #- name: snap
+    #  task: snapshot
+    #  cron: '*/1 * * * *'
+    #  retain: 1
+    #- name: backup
+    #  task: backup
+    #  cron: '*/2 * * * *'
+    #  retain: 1
+
 
 csi:
   attacherImage: longhornio/csi-attacher

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -25,14 +25,14 @@ persistence:
   defaultClass: true
   defaultClassReplicaCount: 3
   recurringJobs:
-    #- name: snap
-    #  task: snapshot
-    #  cron: '*/1 * * * *'
-    #  retain: 1
-    #- name: backup
-    #  task: backup
-    #  cron: '*/2 * * * *'
-    #  retain: 1
+    - name: snap
+      task: snapshot
+      cron: '*/1 * * * *'
+      retain: 1
+    - name: backup
+      task: backup
+      cron: '*/2 * * * *'
+      retain: 1
 
 
 csi:


### PR DESCRIPTION
good evening, 
I was looking into creating a StorageClass that had a baseline backup built in to it by default. 
I noticed that there is no way to specify this in the helm chart , so I wanted to add it. 
Basically, there is a simple if statement to look to see if the value has an array in it, and if it does we convert that to Json. 
If this is your persistence yaml value configuration
```
persistence:
  defaultClass: true
  defaultClassReplicaCount: 3
  recurringJobs:
    - name: snap
      task: snapshot
      cron: '*/1 * * * *'
      retain: 1
    - name: backup
      task: backup
      cron: '*/2 * * * *'
      retain: 1
```
Your StorageClass will be 
```

# Source: longhorn/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: longhorn
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
  labels:
    app.kubernetes.io/name: longhorn
    helm.sh/chart: longhorn-1.0.2
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: longhorn2
    app.kubernetes.io/version: v1.0.2
provisioner: driver.longhorn.io
allowVolumeExpansion: true
parameters:
  numberOfReplicas: "3"
  staleReplicaTimeout: "30"
  fromBackup: ""
  
  recurringJobs: '[{"cron":"*/1 * * * *","name":"snap","retain":1,"task":"snapshot"},{"cron":"*/2 * * * *","name":"backup","retain":1,"task":"backup"}]'
  
  baseImage: ""
```

When it is not defined or left blank like this -- 
```
persistence:
  defaultClass: true
  defaultClassReplicaCount: 3
  recurringJobs:
```
Your StorageClass will be this.

```
# Source: longhorn/templates/storageclass.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: longhorn
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
  labels:
    app.kubernetes.io/name: longhorn
    helm.sh/chart: longhorn-1.0.2
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: longhorn2
    app.kubernetes.io/version: v1.0.2
provisioner: driver.longhorn.io
allowVolumeExpansion: true
parameters:
  numberOfReplicas: "3"
  staleReplicaTimeout: "30"
  fromBackup: ""
  
  baseImage: ""
```
This example code was taken from [Scheduling Backups and Restores](https://longhorn.io/docs/0.8.0/users-guide/backup-and-restore/scheduling-backups-and-snapshots/)
