### PR TITLE
Remove mount /var/run from host to avoid DNS lookup failure

### DIFF
--- a/charts/longhorn/templates/daemonset-sa.yaml
+++ b/charts/longhorn/templates/daemonset-sa.yaml
@@ -45,9 +45,6 @@ spec:
           mountPath: /host/dev/
         - name: proc
           mountPath: /host/proc/
-        - name: varrun
-          mountPath: /var/run/
-          mountPropagation: Bidirectional
         - name: longhorn
           mountPath: /var/lib/longhorn/
           mountPropagation: Bidirectional
@@ -75,9 +72,6 @@ spec:
       - name: proc
         hostPath:
           path: /proc/
-      - name: varrun
-        hostPath:
-          path: /var/run/
       - name: longhorn
         hostPath:
           path: /var/lib/longhorn/


### PR DESCRIPTION
#### Proposed Changes
The host's `/var/run/nscd` leaking into the pod and it caused the DNS lookup failure.

#### Linked Issues
https://github.com/longhorn/longhorn/issues/2200