### PR TITLE
Fix wrong reference in deployment ui template

### DIFF
--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -36,11 +36,11 @@ spec:
       {{- end }}
       {{- if .Values.longhornUI.tolerations }}
       tolerations:
-{{ toYaml .Values.longhornManager.tolerations | indent 6 }}
+        {{- toYaml .Values.longhornUI.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.longhornUI.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
+        {{- toYaml .Values.longhornUI.nodeSelector | nindent 8 }}
       {{- end }}
 ---
 kind: Service


### PR DESCRIPTION
Hi! I noticed that in the deployment-ui template you have a wrong reference to longhornManager, this PR fixes this behavior.

Signed-off-by: Jasstkn <jasssstkn@yahoo.com>