### PR TITLE
Helm chart doesn't allow `-xxx` as valid version

### DIFF
--- a/charts/longhorn/Chart.yaml
+++ b/charts/longhorn/Chart.yaml
@@ -18,7 +18,6 @@ sources:
 - https://github.com/longhorn/longhorn-engine
 - https://github.com/longhorn/longhorn-instance-manager
 - https://github.com/longhorn/longhorn-share-manager
-- https://github.com/longhorn/backing-image-manager
 - https://github.com/longhorn/longhorn-manager
 - https://github.com/longhorn/longhorn-ui
 - https://github.com/longhorn/longhorn-tests

--- a/charts/longhorn/Chart.yaml
+++ b/charts/longhorn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: longhorn
 version: 1.2.0
 appVersion: v1.2.0
-kubeVersion: ">=v1.18.0"
+kubeVersion: ">=1.18.0-r0"
 description: Longhorn is a distributed block storage system for Kubernetes.
 keywords:
 - longhorn


### PR DESCRIPTION
#### Proposal Change

Helm chart doesn't allow `-xxx` as a valid version unless we add `-0` and without prefix `v`.
    
See helm/helm#9371 for details.

Besides that, the semver parser doesn't allow with prefix `v`.
https://github.com/rancher/rancher/blob/release/v2.5.9/pkg/catalog/manager/manager.go#L218-L221

#### Issue

https://github.com/longhorn/longhorn/issues/2963