### PR TITLE
feat(longhorn-UI): Allow specyfing loadBalancer IP/SourceRanges

### DIFF
--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -59,6 +59,16 @@ spec:
   {{- else }}
   type: {{ .Values.service.ui.type }}
   {{- end }}
+
+  {{- if and (eq .Values.service.ui.type "ClusterIP") .Values.service.ui.type }}
+  clusterIP: {{ .Values.service.ui.type }}
+  {{- end }}
+  {{- if and .Values.service.ui.loadBalancerIP (eq .Values.service.ui.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.ui.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.service.ui.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   selector:
     app: longhorn-ui
   ports:


### PR DESCRIPTION
This change allows users to specify loadBalancerIP/SourceRanges while using loadBalancer service type in Longhorn-UI service.