### PR TITLE
Allow for services to be in custom namespace

### DIFF
--- a/charts/longhorn/templates/services.yaml
+++ b/charts/longhorn/templates/services.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
   name: longhorn-engine-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   clusterIP: None
   selector:
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
   name: longhorn-replica-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   clusterIP: None
   selector:


### PR DESCRIPTION
The rest of the chart allows for custom namespaces to be used but the addition of these 2 services are breaking that which kills the roll-out via GitOps tools like Flux