### PR TITLE
Make services.yaml respect the namespace override

### DIFF
--- a/charts/longhorn/templates/services.yaml
+++ b/charts/longhorn/templates/services.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
   name: longhorn-engine-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   clusterIP: None
   selector:
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
   name: longhorn-replica-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   clusterIP: None
   selector:


### PR DESCRIPTION
This allows us to actually user the `namespaceOverride` value in values.yaml. So far the services.yaml had the original namespace `longhorn-system` as fixed value.