### PR TITLE
Fix: Use helper template for headless service namespace

### DIFF
--- a/charts/longhorn/templates/services.yaml
+++ b/charts/longhorn/templates/services.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
   name: longhorn-engine-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   clusterIP: None
   selector:
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   labels: {{- include "longhorn.labels" . | nindent 4 }}
   name: longhorn-replica-manager
-  namespace: longhorn-system
+  namespace: {{ include "release_namespace" . }}
 spec:
   clusterIP: None
   selector:


### PR DESCRIPTION
**Overview**

This PR replaces the hardcoded namespace fields in the headless services with the common template helper "release_namespace".

**Error and Fix**

I run longhorn in custom namespace in my cluster. When updating to `1.2.3`, I get an error that namespace `longhorn-system` does not exist.

```tf
helm_release.longhorn: Modifying... [id=longhorn]
╷
│ Error: failed to create resource: namespaces "longhorn-system" not found
│ 
│   with helm_release.longhorn,
│   on longhorn.tf line 1, in resource "helm_release" "longhorn":
│    1: resource "helm_release" "longhorn" {
```

To fix, I've replaced the hardcoded namespace `longhorn-system` in the recently added services with the common template helper used in other templates.
