### PR TITLE
Add recurring-jobs-generator chart

### DIFF
--- a/charts/recurring-job-generator/.helmignore
+++ b/charts/recurring-job-generator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/recurring-job-generator/Chart.yaml
+++ b/charts/recurring-job-generator/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: recurring-jobs-generator
+description: Longhorn Recurring Jobs Generator
+type: application
+version: 1.0.0
+kubeVersion: ">=1.18.0-0"
+keywords:
+- longhorn
+- storage
+- distributed
+- block
+- device
+- iscsi
+- nfs
+maintainers:
+- name: Longhorn maintainers
+  email: maintainers@longhorn.io
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/icon/color/longhorn-icon-color.png

--- a/charts/recurring-job-generator/README.md
+++ b/charts/recurring-job-generator/README.md
@@ -1,0 +1,7 @@
+# recurring-jobs-generator
+Chart for generating Longhorn Recurring Jobs
+
+### How to use
+
+See `values.yaml`. In particular, you will want to provide a value for `groups`. If you have `createStorageClasses` = `true`,
+you will want to provide values for `parameters`. The `values.yaml` has much more information.

--- a/charts/recurring-job-generator/templates/recurringjobs.yaml
+++ b/charts/recurring-job-generator/templates/recurringjobs.yaml
@@ -1,0 +1,153 @@
+{{- /* $generatedJobs is fed into a range to generate each RecurringJob */}}
+{{- $generatedJobs := dict -}}
+
+{{- /* $generatedGroups is a dict whose keys are the names of the generated jobs
+      and the values of those keys are an array of group names */}}
+{{- $generatedGroups := dict -}}
+{{- /* See below for an example of these objects */}}
+
+{{- /* First round, populate $generatedJobs and $generatedGroups */}}
+{{- range $groupName, $groupSettings := .Values.groups -}}
+  {{- range $jobType, $job := $groupSettings -}}
+    {{- if or (eq $jobType "snapshot") (eq $jobType "backup") -}}
+      {{- range $job -}}
+        {{- $concurrency := ( .concurrency | default $.Values.defaultConcurrency ) -}}
+
+        {{- /* Example $jobName: snapshot-10m-retain-1-concurrency-4 */}}
+        {{- $jobName := printf "%s-%s-retain-%s-concurrency-%s" $jobType .interval (.retain | toString) ( $concurrency | toString ) -}}
+
+        {{- $jobProperties := dict -}}
+        {{- $_ := set $jobProperties "interval" .interval -}}
+        {{- $_ := set $jobProperties "jobType" $jobType -}}
+        {{- $_ := set $jobProperties "retain" .retain -}}
+        {{- $_ := set $jobProperties "concurrency" $concurrency -}}
+
+        {{- $_ := set $generatedJobs $jobName $jobProperties -}}
+        {{- $existingGroupList := get $generatedGroups $jobName | default list -}}
+        {{- /* Set and deduplicate the groups for this $jobName */}}
+        {{- $_ := set $generatedGroups $jobName ( append $existingGroupList $groupName | uniq ) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $numberOfGroups := len $generatedGroups -}}
+{{- $jobIndex := 0 -}}
+
+{{- /* Second round, calculate cron expressions for the jobs based on how many jobs there are */}}
+{{- range $groupName, $groupSettings := .Values.groups -}}
+  {{- range $jobType, $job := $groupSettings -}}
+    {{- if or (eq $jobType "snapshot") (eq $jobType "backup") -}}
+      {{- range $job -}}
+        {{- $concurrency := ( .concurrency | default $.Values.defaultConcurrency ) -}}
+        {{- /* Example $jobName: snapshot-10m-retain-1-concurrency-4 */}}
+        {{- $jobName := printf "%s-%s-retain-%s-concurrency-%s" $jobType .interval (.retain | toString) ( $concurrency | toString ) -}}
+
+        {{- $jobProperties := get $generatedJobs $jobName -}}
+
+        {{- /* These values will always get overwritten, we just need an initial value */}}
+        {{- $minute := "99" -}}
+        {{- $hour := "99" -}}
+        {{- $day := "99" -}}
+
+        {{- $minuteStep := int $.Values.minuteStep -}}
+        {{- /* Here we set the minute for cron expressions that have other fields set */}}
+        {{- if not (regexMatch "[0-9]+m" .interval) -}}
+          {{- if $.Values.spreadCronStartTimes -}}
+            {{- /* Use modulus to pick a minute between 0 and 59, in $minuteStep minute intervals */}}
+            {{- $minuteOptions := untilStep 0 59 $minuteStep -}}
+            {{- $minute = (toString (index $minuteOptions (mod $jobIndex (len $minuteOptions)))) -}}
+          {{- else -}}
+            {{- $minute = "0" -}}
+          {{- end -}}
+        {{- else -}}
+          {{- /* The interval was something like "10m", so make $minute equals something like "35/10" */}}
+          {{- $minuteInterval := trimSuffix "m" .interval -}}
+          {{- /* Make a list of all the possible options that are $minuteStep apart but less than $minuteInterval */}}
+          {{- $minuteOptions := untilStep 0 (atoi $minuteInterval) $minuteStep -}}
+          {{- /* Use modulus to pick a minute between 0 and $minuteInterval */}}
+          {{- $customMinuteStart := index $minuteOptions (mod $jobIndex (len $minuteOptions)) -}}
+          {{- $minute = (printf "%s/%s" ($customMinuteStart | toString) $minuteInterval) -}}
+        {{- end -}}
+        
+        {{- $hourStep := int $.Values.hourStep -}}
+        {{- if or (regexMatch "[0-9]+m" .interval) (eq "1h" .interval) -}}
+          {{- $hour = "*" -}}
+        {{- /* Here we set the hour for cron expressions that have days or more set */}}
+        {{- else if not (regexMatch "[0-9]+h" .interval) -}}
+          {{- if $.Values.spreadCronStartTimes -}}
+            {{- $hourOptions := untilStep 0 23 $hourStep -}}
+            {{- $hour = (toString (index $hourOptions (mod $jobIndex (len $hourOptions)))) -}}
+          {{- else -}}
+            {{- $hour = "0" -}}
+          {{- end -}}
+        {{- else -}}
+          {{- $hourInterval := trimSuffix "h" .interval -}}
+          {{- /* Make a list of all the possible options that are $hourStep apart but less than $hourInterval */}}
+          {{- $hourOptions := untilStep 0 (atoi $hourInterval) $hourStep -}}
+          {{- /* Use modulus to pick an hour between 0 and $hourInterval */}}
+          {{- $customHourStart := index $hourOptions (mod $jobIndex (len $hourOptions)) -}}
+          {{- $hour = (printf "%s/%s" ($customHourStart | toString) $hourInterval) -}}
+        {{- end -}}
+
+        {{- $day := "*" -}}
+        {{- /* If minutes, hours or '1d' is set, $day = "*" */}}
+        {{- if or (or (regexMatch "[0-9]+m" .interval) (regexMatch "[0-9]+h" .interval) (eq "1d" .interval)) -}}
+          {{- $day = "*" -}}
+        {{- else -}}
+          {{- $dayInterval := trimSuffix "d" .interval | toString -}}
+          {{- /* We should always use "*" which evaluates to "Every X days" */}}
+          {{- $day = (printf "*/%s" ($dayInterval | toString)) -}}
+        {{- end -}}
+
+        {{- $cron := printf "%s %s %s * *" $minute $hour $day -}}
+        {{- $_ := set $jobProperties "cron" $cron -}}
+        {{- $_ := set $generatedJobs $jobName $jobProperties -}}
+        {{- $jobIndex = add1 $jobIndex -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /*
+What $generatedJobs looks like
+$generatedJobs:
+  snapshot-10m-retain-1-concurrency-4:
+    interval: 10m
+    cron: "0/10 * * * *"
+    retain: 1
+    jobType: snapshot
+    concurrency: 4
+  snapshot-1h-retain-1-concurrency-4:
+    [...]
+
+What $generatedGroups looks like
+$generatedGroups:
+  snapshot-10m-retain-1-concurrency-4:
+    - ExampleGroup
+    - OtherGroup
+  snapshot-1h-retain-1-concurrency-4:
+    - [...]
+*/}}
+
+{{- range $name, $properties := $generatedJobs }}
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: {{ $name }}
+  {{- with $.Values.namespaceOverride }}
+  namespace: {{ . }}
+  {{- end }}
+spec:
+  cron: {{ $properties.cron | quote }}
+  task: {{ $properties.jobType }}
+  groups:
+  {{- range (get $generatedGroups $name ) }}
+    - {{ . }}
+  {{- end }}
+  retain: {{ $properties.retain }}
+  concurrency: {{ $properties.concurrency }}
+  labels:
+    jobName: {{ $name }}
+---
+{{- end }}

--- a/charts/recurring-job-generator/templates/storageclass.yaml
+++ b/charts/recurring-job-generator/templates/storageclass.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.createStorageClasses -}}
+{{- range $group, $property := .Values.groups -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-{{ lower $group }}
+provisioner: driver.longhorn.io
+{{- /* We can't use 'default' because unset evaluates to false */}}
+{{ $allowVolumeExpansion := false }}
+{{- if eq $property.allowVolumeExpansion false -}}
+  {{- $allowVolumeExpansion = false -}}
+{{- else if eq $property.allowVolumeExpansion true -}}
+  {{- $allowVolumeExpansion = true -}}
+{{- else -}}
+  {{- $allowVolumeExpansion = $.Values.allowVolumeExpansion -}}
+{{- end -}}
+allowVolumeExpansion: {{ $allowVolumeExpansion }}
+reclaimPolicy: "{{ $property.reclaimPolicy | default $.Values.reclaimPolicy }}"
+parameters:
+{{- /* Set parameters if they're specified at the top level OR for this specific group */}}
+{{- if or (not (empty $.Values.parameters)) (not (empty $property.parameters)) -}}
+  {{- $parameters := mergeOverwrite dict ($.Values.parameters | default dict) ($property.parameters | default dict) -}}
+  {{- range $key, $value := $parameters }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end -}}
+{{ end }}
+  recurringJobSelector: >-
+    [
+      {
+      "name":"{{ $group }}",
+      "isGroup":true
+      }
+    ]
+---
+{{ end }}
+{{- end -}}

--- a/charts/recurring-job-generator/values.yaml
+++ b/charts/recurring-job-generator/values.yaml
@@ -1,0 +1,70 @@
+namespaceOverride: ""
+
+# Default job concurrency
+defaultConcurrency: 4
+
+# Whether or not to spread the jobs so that the start times are "randomized" (actually deterministic)
+# If this is false, minutes and hours in generated cron expressions will be 0
+# Examples if true:
+# "15/30 * * * *"
+# "5/15 4 * * *"
+# Examples if false:
+# "0 * * * *"
+# "0 0/2 * * *"
+spreadCronStartTimes: true
+
+# How separated should the minutes and hours be on the generated cron expressions
+# Example: if minuteStep: 5, then the cron expression will be like "0/10 * * * *", "5/10 * * * *"
+minuteStep: 5
+hourStep: 2
+
+# Optionally create storageclasses for each group
+# This is disabled by default because the Helm release will fail if
+# an upgrade is run and it tries to remove an in-use StorageClass
+createStorageClasses: false
+
+# Default StorageClass properties
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+
+# Longhorn-specific parameters
+parameters: {}
+  # replicaAutoBalance: "ignored"
+  # dataLocality: "disabled"
+  # numberOfReplicas: "3"
+  # staleReplicaTimeout: "2880"
+
+# # Uncomment this section to see an example configuration with comments.
+# # Group names must start and end with alphanumeric characters
+# # Group names can only have [A-Za-z0-9\-_.] or [A-Za-z0-9\-] if creating StorageClasses
+# groups:
+#   # Quoting isn't required, but improves readability
+#   "ExampleGroup":
+#     # You may override these properties for the storage classes for this group
+#     # This only takes effect if createStorageClasses is true
+#     allowVolumeExpansion: true
+#     reclaimPolicy: Delete
+#     # You can specify longhorn-specific parameters under this key
+#     parameters:
+#       replicaAutoBalance: "best-effort"
+#       dataLocality: "best-effort"
+#       numberOfReplicas: "2"
+#       staleReplicaTimeout: "30"
+#     # At least one of either "snapshot" or "backup" is required.
+#     snapshot:
+#       - interval: 10m
+#         retain: 6
+#         # You may override the defaultConcurrency on each interval specification
+#         concurrency: 10
+#     backup: 
+#       - interval: 1h
+#         retain: 5
+#       - interval: 6h
+#         retain: 4
+#   "ExampleGroupTwo":
+#     snapshot:
+#       - interval: 1h
+#         retain: 6
+#     backup: 
+#       - interval: 1d
+#         retain: 4


### PR DESCRIPTION
In this PR, we add the recurring-jobs-generator chart. This chart's purpose is to generate `RecurringJob`s (and associated storageClasses) by simply specifying snapshot and backup intervals for one or more groups.

Some notes about this PR:
- I have not created `questions.yml` or `app-readme.md` because I'm a little unfamiliar and I don't know what the appetite for this chart would be in this repo. I can create them if necessary.
- I have tried to comment as much as I can, but unfortunately it is still hard to follow in places, particularly when generating the `RecurringJob`s.
- I have not included default groups for demonstration because of how Helm works--if a user specifies their own groups, then their groups plus the default example groups will be created. Examples are included but commented out.
- I've tested an earlier version of this chart (located [here](https://github.com/tyzbit/helm-charts/tree/main/charts/longhorn-recurring-jobs)) pretty thoroughly with different combinations of parameters. ~~The difference between that chart and this PR is that chart assumes specific parameters for the storageClasses, whereas this one supports any parameters. I intend to true up that chart to what's in this branch should this MR be rejected.~~ I've updated that chart.
- The version is set to 1.0.0; perhaps it should be kept synchronized with the longhorn chart so that backwards-incompatible changes to `RecurringJob`s or storageClasses can be accommodated.