### PR TITLE
fix private registry pull secrets not work with serviceaccount

### DIFF
--- a/charts/longhorn/templates/serviceaccount.yaml
+++ b/charts/longhorn/templates/serviceaccount.yaml
@@ -8,3 +8,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if .Values.privateRegistry.createSecret }}
+imagePullSecrets:
+  - name: {{ .Values.privateRegistry.createSecret }}
+{{- end }}


### PR DESCRIPTION
In the helm chart, when we set the private-registry-pull-secrets, it's not work because the serviceaccount did not set the imagePullSecrets.
Signed-off-by: tgfree <tgfree7@gmail.com>