### PR TITLE
Add new variable to set the number of replica for the webhook

### DIFF
--- a/charts/longhorn/templates/deployment-webhook.yaml
+++ b/charts/longhorn/templates/deployment-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   name: longhorn-conversion-webhook
   namespace: {{ include "release_namespace" . }}
 spec:
-  replicas: 2
+  replicas: {{ .Values.webhook.conversionReplicaCount }}
   selector:
     matchLabels:
       app: longhorn-conversion-webhook
@@ -74,7 +74,7 @@ metadata:
   name: longhorn-admission-webhook
   namespace: {{ include "release_namespace" . }}
 spec:
-  replicas: 2
+  replicas: {{ .Values.webhook.admissionReplicaCount }}
   selector:
     matchLabels:
       app: longhorn-admission-webhook

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -77,6 +77,10 @@ csi:
   resizerReplicaCount: ~
   snapshotterReplicaCount: ~
 
+webhook:
+  conversionReplicaCount: 2
+  admissionReplicaCount: 2
+
 defaultSettings:
   backupTarget: ~
   backupTargetCredentialSecret: ~


### PR DESCRIPTION
Creation of two variables: `webhook.conversionReplicaCount` and `webhook.admissionReplicaCount` to handle the number of replicas for the conversion and admission webhook.
By default, these variables are set to 2.