### PR TITLE
Add ServiceMonitor in helm chart

### DIFF
--- a/charts/longhorn/templates/servicemonitor.yaml
+++ b/charts/longhorn/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if  .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: longhorn-prometheus-servicemonitor
+  namespace: {{ include "release_namespace" . }}
+  labels:
+    {{- include "longhorn.labels" . | nindent 4 }}
+    name: longhorn-prometheus-servicemonitor
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  namespaceSelector:
+    matchNames:
+    - {{ include "release_namespace" . }}
+  endpoints:
+  - port: manager

--- a/charts/longhorn/templates/servicemonitor.yaml
+++ b/charts/longhorn/templates/servicemonitor.yaml
@@ -16,3 +16,4 @@ spec:
     - {{ include "release_namespace" . }}
   endpoints:
   - port: manager
+{{- end }}

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -330,3 +330,8 @@ annotations: {}
 serviceAccount:
   # Annotations to add to the service account
   annotations: {}
+
+metrics:
+  serviceMonitor:
+    # Enable this to create the ServiceMonitor
+    enabled: false


### PR DESCRIPTION
To ensure you can create the service monitor without having to deploy it manually after installation, I added a values **metrics.serviceMonitor.enabled**. The default values is **false**, but if set to **true** it creates the service monitor according to the documentation.