### PR TITLE
Add Ingress PathType Configuration

### DIFF
--- a/charts/longhorn/templates/ingress.yaml
+++ b/charts/longhorn/templates/ingress.yaml
@@ -34,10 +34,10 @@ spec:
             service:
               name: longhorn-frontend
               port:
-                number: 80
+                name: http
             {{- else }}
             serviceName: longhorn-frontend
-            servicePort: 80
+            servicePort: http
             {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/longhorn/templates/ingress.yaml
+++ b/charts/longhorn/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
       paths:
         - path: {{ default "" .Values.ingress.path }}
           {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-          pathType: ImplementationSpecific
+          pathType: {{ .Values.ingress.pathType }}
           {{- end }}
           backend:
             {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -291,6 +291,11 @@ ingress:
   ## then you can access the UI by using the following full path {{host}}+{{path}}
   path: /
 
+  ## The pathType configures how the Ingress Controller implementation interprets the path
+  ## There are three supported path types, please see
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  pathType: ImplementationSpecific
+
   ## Ingress annotations done as key:value pairs
   ## If you're using kube-lego, you will want to add:
   ## kubernetes.io/tls-acme: true


### PR DESCRIPTION
Changes

- Add Ingress Configuration for when certain Ingress Controller implementations require a different value
- Change mapping of Ingress resource to Service from using port number to port name for a more explicit link between the two resources