### PR TITLE
Allow to set annotations for the UI service

### DIFF
--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -89,7 +89,11 @@ metadata:
     {{- end }}
   name: longhorn-frontend
   namespace: {{ include "release_namespace" . }}
-spec:
+  {{- if .Values.longhornManager.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.longhornManager.serviceAnnotations | indent 4 }}
+  {{- end }}
+sspec:
   {{- if eq .Values.service.ui.type "Rancher-Proxy" }}
   type: ClusterIP
   {{- else }}

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -219,6 +219,11 @@ longhornUI:
   ## and uncomment this example block
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
+  serviceAnnotations: {}
+  ## If you want to set annotations for the Longhorn Manager service, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  annotation-key1: "annotation-value1"
+  #  annotation-key2: "annotation-value2"
 
 longhornConversionWebhook:
   replicas: 2


### PR DESCRIPTION
Hi,

Thank you very much for your amazing work. I really like longhorn and this chart makes everything way easier!

This small contribution would allow to specify annotations for the UI service. 
I am using this annotation to set a specific IP for the load balancer that I keep in front of the UI using MetalLb. 

Hope you will merge this contribution so I don't have to modify the service after the creation :)

Thank you again for your work!

Best
Riccardo