### PR TITLE
conditional to disable helm preUpgrade job

### DIFF
--- a/charts/longhorn/templates/preupgrade-job.yaml
+++ b/charts/longhorn/templates/preupgrade-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.preHelmUpgradeCheckerJob.enabled }}
+{{- if .Values.helmPreUpgradeCheckerJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/longhorn/templates/preupgrade-job.yaml
+++ b/charts/longhorn/templates/preupgrade-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preHelmUpgradeCheckerJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -54,3 +55,4 @@ spec:
 {{ toYaml .Values.longhornManager.nodeSelector | indent 8 }}
         {{- end }}
       {{- end }}
+{{- end }}

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -102,7 +102,7 @@ persistence:
     selector: ""
   removeSnapshotsDuringFilesystemTrim: ignored # "enabled" or "disabled" otherwise
 
-preHelmUpgradeCheckerJob:
+helmPreUpgradeCheckerJob:
   enabled: true
 
 csi:

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -102,6 +102,9 @@ persistence:
     selector: ""
   removeSnapshotsDuringFilesystemTrim: ignored # "enabled" or "disabled" otherwise
 
+preHelmUpgradeCheckerJob:
+  enabled: true
+
 csi:
   kubeletRootDir: ~
   attacherReplicaCount: ~


### PR DESCRIPTION
The preUpgrade job was added in 1.15 and introduces a breaking change for any ArgoCD users when creating a new environment.  ArgoCD does not have a method for differentiating between a helm install or a helm upgrade.  https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks

Not being able to differentiate between an install or upgrade is not an problem in most cases because hooks are only available to the helm binary.  Kubernetes was not built around Helm and hooks are not part of the core kubernetes api.  Hooks are at best a makeshift shim.  Relying upon hooks introduce undesired complexity when deploying applications and should be avoided because they lack scalability/flexibility.


It appears the preUpgrade job was created to avoid single pod per node nature of daemonsets.  Having a daemonset pod fail will result in that nodes storage being unavailable.    The hook was a preventative measure to catch a incompatibilities before there is an issue.

This pull request is for adding a parameter to make the helm hook job optional.  Long term this would be best moved the application through the use of a controller or operator.  