### PR TITLE
Update values.yaml - update documentation link for ingress-nginx annotations

### DIFF
--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -256,7 +256,7 @@ ingress:
   ## kubernetes.io/tls-acme: true
   ##
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   annotations:


### PR DESCRIPTION
The old link doesn't work because the repo uses `main` instead of `master` for the default branch now :) Happy to bump the chart version if you'd like, but this is just a doc link, so it's up to you.

Thanks!