### PR TITLE
allow configuration of manager debug level

### DIFF
--- a/charts/longhorn/templates/daemonset-sa.yaml
+++ b/charts/longhorn/templates/daemonset-sa.yaml
@@ -30,7 +30,9 @@ spec:
           privileged: true
         command:
         - longhorn-manager
+        {{- if .Values.longhornManager.log.debug }}
         - -d
+        {{- end }}
         {{- if eq .Values.longhornManager.log.format "json" }}
         - -j
         {{- end }}

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -170,6 +170,8 @@ longhornManager:
   log:
     ## Allowed values are `plain` or `json`.
     format: plain
+    ## Enable debug log level
+    debug: true
   priorityClass: ~
   tolerations: []
   ## If you want to set tolerations for Longhorn Manager DaemonSet, delete the `[]` in the line above


### PR DESCRIPTION
Currently the longhorn manager always runs with debug level.

This PR allows disabling this.
By default the debug level is still enabled.