### PR TITLE
Allow disabling Longhorn UI

### DIFF
--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.longhornUI.enabled }}
 {{- if .Values.openshift.enabled }}
 {{- if .Values.openshift.ui.route }}
 # https://github.com/openshift/oauth-proxy/blob/master/contrib/sidecar.yaml
@@ -180,3 +181,4 @@ spec:
     {{- else }}
     nodePort: null
     {{- end }}
+{{- end }}

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -380,6 +380,8 @@ longhornDriver:
   #  label-key2: "label-value2"
 
 longhornUI:
+  # -- Setting that allows you to enable the Longhorn UI.
+  enabled: true
   # -- Replica count for Longhorn UI.
   replicas: 2
   # -- PriorityClass for Longhorn UI.


### PR DESCRIPTION
Allow disabling Longhorn UI

This pull request introduces the ability to disable the deployment of the Longhorn UI during installation. This caters to users in constrained environments where direct interaction with the Kubernetes API is preferred for managing Longhorn volumes.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
