### PR TITLE
Update release-ondemand.yml - add autogenerated github release notes

### DIFF
--- a/.github/workflows/release-ondemand.yml
+++ b/.github/workflows/release-ondemand.yml
@@ -35,3 +35,4 @@ jobs:
       uses: helm/chart-releaser-action@v1.0.0
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        CR_GENERATE_RELEASE_NOTES: true


### PR DESCRIPTION
This sets the  `--generate-release-notes` flag for the chart releaser `cr` command, which according to the [help](https://github.com/helm/chart-releaser?tab=readme-ov-file#create-github-releases-from-helm-chart-packages) is:

>  Whether to automatically generate the name and body for this release.  See https://docs.github.com/en/rest/releases/releases`

We use it over at nextcloud/helm and here's an example release it generates:

https://github.com/nextcloud/helm/releases/tag/nextcloud-6.0.1

This is helpful so that there's a bit more detail in tools like RenovateBot and Dependabot that automatically generate PRs for version updates. Here's an example of PR that was generated using github release notes: https://github.com/small-hack/argocd-apps/pull/1195

See also for `v1.6.x` branch: https://github.com/longhorn/charts/pull/176