### PR TITLE
Additinoal labels for all resources (v1.7.x)

### DIFF
--- a/charts/longhorn/templates/_helpers.tpl
+++ b/charts/longhorn/templates/_helpers.tpl
@@ -35,6 +35,9 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- with .Values.global.additionalLabels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
 {{- end -}}
 
 

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 global:
+  # -- Addtional labels for all the resources
+  additionalLabels: {}
   # -- Toleration for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
   tolerations: []
   # -- Node selector for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.


### PR DESCRIPTION
Here and there, some installations forces to use predefined labels. This helps to use additional labels. 

I believe this PR is incomplete without updating the README. However, I couldn't figure out how to do that. 

Also, I couldn't figure out how to tell those labels to longhorn-manager. Therefore, things like csi-attacher etc would also use the those labels. Any guidance appreciated. 