### PR TITLE
Allow setting resource requests/limits on user-deployed components 

### DIFF
--- a/charts/longhorn/README.md
+++ b/charts/longhorn/README.md
@@ -81,6 +81,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | global.cattle.windowsCluster.tolerations | list | `[{"effect":"NoSchedule","key":"cattle.io/os","operator":"Equal","value":"linux"}]` | Toleration for Linux nodes that can run user-deployed Longhorn components. |
 | global.nodeSelector | object | `{}` | Node selector for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
 | global.tolerations | list | `[]` | Toleration for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
+| global.resources | object | `{}` | Resource requests and limits for user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
 
 ### Network Policies
 
@@ -122,6 +123,16 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | image.openshift.oauthProxy.repository | string | `""` | Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users. |
 | image.openshift.oauthProxy.tag | string | `""` | Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.15, which is available at quay.io/openshift/origin-oauth-proxy:4.15). This setting applies only to OpenShift users. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI. |
+
+### Resource settings
+
+| Key                               | Type   | Default | Description                                                            |
+|-----------------------------------|--------|---------|------------------------------------------------------------------------|
+| resources.longhorn.manager        | object | `{}`    | Resource requests and limits for the Longhorn Manager component.       |
+| resources.longhorn.ui             | object | `{}`    | Resource requests and limits for the Longhorn UI component.            |
+| resources.longhorn.shareManager   | object | `{}`    | Resource requests and limits for the Longhorn Share Manager component. |
+| resources.longhorn.driverDeployer | object | `{}`    | Resource requests and limits for the Longhorn Driver Deployer.         |
+| resources.openshift.oauthProxy    | object | `{}`    | Resource requests and limits for the OAuth Proxy component.            |
 
 ### Service Settings
 

--- a/charts/longhorn/templates/daemonset-sa.yaml
+++ b/charts/longhorn/templates/daemonset-sa.yaml
@@ -22,6 +22,10 @@ spec:
       - name: longhorn-manager
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.resources.longhorn.manager | default .Values.global.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           privileged: true
         command:
@@ -105,8 +109,12 @@ spec:
           value: /go-cover-dir/
         {{- end }}
       - name: pre-pull-share-manager-image
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.resources.longhorn.shareManager | default .Values.global.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         command: ["sh", "-c", "echo share-manager image pulled && sleep infinity"]
       volumes:
       - name: boot

--- a/charts/longhorn/templates/deployment-driver.yaml
+++ b/charts/longhorn/templates/deployment-driver.yaml
@@ -22,6 +22,10 @@ spec:
         - name: longhorn-driver-deployer
           image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.resources.longhorn.driverDeployer | default .Values.global.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
           - longhorn-manager
           - -d

--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -76,6 +76,10 @@ spec:
         image: ""
         {{- end }}
         imagePullPolicy: IfNotPresent
+        {{- with .Values.resources.openshift.oauthProxy | default .Values.global.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.openshift.ui.proxy | default 8443 }}
           name: public
@@ -96,6 +100,10 @@ spec:
       - name: longhorn-ui
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.ui.repository }}:{{ .Values.image.longhorn.ui.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.resources.longhorn.ui | default .Values.global.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name : nginx-cache
           mountPath: /var/cache/nginx/

--- a/charts/longhorn/templates/postupgrade-job.yaml
+++ b/charts/longhorn/templates/postupgrade-job.yaml
@@ -19,6 +19,10 @@ spec:
       - name: longhorn-post-upgrade
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.resources.longhorn.manager | default .Values.global.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
         - longhorn-manager
         - post-upgrade

--- a/charts/longhorn/templates/preupgrade-job.yaml
+++ b/charts/longhorn/templates/preupgrade-job.yaml
@@ -20,6 +20,10 @@ spec:
       - name: longhorn-pre-upgrade
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.resources.longhorn.manager | default .Values.global.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           privileged: true
         command:

--- a/charts/longhorn/templates/uninstall-job.yaml
+++ b/charts/longhorn/templates/uninstall-job.yaml
@@ -19,6 +19,10 @@ spec:
       - name: longhorn-uninstall
         image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.resources.longhorn.manager | default .Values.global.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
         - longhorn-manager
         - uninstall

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -6,6 +6,8 @@ global:
   tolerations: []
   # -- Node selector for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
   nodeSelector: {}
+  # -- Resource requests and limits for user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
+  resources: {}
   cattle:
     # -- Default system registry.
     systemDefaultRegistry: ""
@@ -107,6 +109,27 @@ image:
       tag: ""
   # -- Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI.
   pullPolicy: IfNotPresent
+resources:
+  # -- Resource requests and limits for all user-deployed components, such as Longhorn Manager, Longhorn driver, and Longhorn UI.
+  # Example:
+  # requests:
+  #   cpu: "100m"
+  #   memory: "128Mi"
+  # limits:
+  #   cpu: "500m"
+  #   memory: "256Mi"
+  longhorn:
+    # -- Resource requests and limits for the Longhorn Manager component.
+    manager: {}
+    # -- Resource requests and limits for the Longhorn UI component.
+    ui: {}
+    # -- Resource requests and limits for the Longhorn Share Manager component.
+    shareManager: {}
+    # -- Resource requests and limits for the Longhorn Driver Deployer component.
+    driverDeployer: {}
+  openshift:
+    # -- Resource requests and limits for the OAuth Proxy component.
+    oauthProxy: {}
 service:
   ui:
     # -- Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy")


### PR DESCRIPTION
This PR adds support to add `resources` `requests` and `limits` in 2 ways:
 - as a global parameters if you want to have one shared resources strategy for all use components
 - as a per-component based parameter
 
 | Key | Type | Default | Description |
|-----|------|---------|-------------|
 | global.resources | object | `{}` | Resource requests and limits for user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
| resources.longhorn.manager        | object | `{}`    | Resource requests and limits for the Longhorn Manager component.       |
| resources.longhorn.ui             | object | `{}`    | Resource requests and limits for the Longhorn UI component.            |
| resources.longhorn.shareManager   | object | `{}`    | Resource requests and limits for the Longhorn Share Manager component. |
| resources.longhorn.driverDeployer | object | `{}`    | Resource requests and limits for the Longhorn Driver Deployer.         |
| resources.openshift.oauthProxy    | object | `{}`    | Resource requests and limits for the OAuth Proxy component.            |

**Reference:** https://github.com/longhorn/longhorn/issues/3186
**Comment:** https://github.com/longhorn/longhorn/issues/3186#issuecomment-2816665008