### PR TITLE
fix: make the ui route match the annotation

### DIFF
--- a/charts/longhorn/templates/serviceaccount.yaml
+++ b/charts/longhorn/templates/serviceaccount.yaml
@@ -24,7 +24,7 @@ metadata:
   {{- if not .Values.serviceAccount.annotations }}
   annotations:
   {{- end }}
-    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"longhorn-ui"}}'
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ .Values.openshift.ui.route }}"}}'
   {{- end }}
   {{- end }}
 ---


### PR DESCRIPTION
If the Openshift route is set to any other value but longhorn-ui then it is not possible to login