### PR TITLE
feat: add support for custom annotations in the UI service

### DIFF
--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -151,6 +151,10 @@ metadata:
     {{- end }}
   name: longhorn-frontend
   namespace: {{ include "release_namespace" . }}
+  {{- with .Values.service.ui.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if eq .Values.service.ui.type "Rancher-Proxy" }}
   type: ClusterIP

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -113,6 +113,12 @@ service:
     type: ClusterIP
     # -- NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767.
     nodePort: null
+    # -- Annotation for the Longhorn UI service.
+    annotations: {}
+    ## If you want to set annotations for the Longhorn UI service, delete the `{}` in the line above
+    ## and uncomment this example block
+    #  annotation-key1: "annotation-value1"
+    #  annotation-key2: "annotation-value2"
   manager:
     # -- Service type for Longhorn Manager.
     type: ClusterIP


### PR DESCRIPTION
I'm using the Longhorn Helm chart in my homelab setup.

During configuration, I found that the chart doesn't support adding custom annotations to the UI service. 
As a workaround, I had to use [FluxCD postRenderers](https://github.com/josimar-silva/homelab/pull/8/files), which added unnecessary complexity.

This PR adds native support for custom annotations to the UI service, making the chart more flexible for other use cases:

E.g: values.yaml
```yaml
service:
  ui:
    type: "LoadBalancer"
    loadBalancerIP: 192.168.10.101
    annotations:
      external-dns.alpha.kubernetes.io/hostname: longhorn.homelab.lan
      metallb.io/ip-allocated-from-pool: homelab-local-pool
      metallb.universe.tf/allow-shared-ip: longhorn-svc
```

Renderer UI Service:
```yaml
kind: Service
apiVersion: v1
metadata:
  labels:
    app.kubernetes.io/name: longhorn
    helm.sh/chart: longhorn-1.9.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: longhorn-test
    app.kubernetes.io/version: v1.9.0
    app: longhorn-ui
  name: longhorn-frontend
  namespace: longhorn-system
  annotations:
    external-dns.alpha.kubernetes.io/hostname: longhorn.homelab.lan
    metallb.io/ip-allocated-from-pool: homelab-local-pool
    metallb.universe.tf/allow-shared-ip: longhorn-svc
spec:
  type: LoadBalancer
  loadBalancerIP: 192.168.10.101
  selector:
    app: longhorn-ui
  ports:
  - name: http
    port: 80
    targetPort: http
    nodePort: null
```