### PR TITLE
Implement standardized image registry override values

### DIFF
--- a/charts/longhorn/README.md
+++ b/charts/longhorn/README.md
@@ -79,6 +79,7 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 | global.cattle.windowsCluster.enabled | bool | `false` | Setting that allows Longhorn to run on a Rancher Windows cluster. |
 | global.cattle.windowsCluster.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for Linux nodes that can run user-deployed Longhorn components. |
 | global.cattle.windowsCluster.tolerations | list | `[{"effect":"NoSchedule","key":"cattle.io/os","operator":"Equal","value":"linux"}]` | Toleration for Linux nodes that can run user-deployed Longhorn components. |
+| global.imageRegistry | string | `""` | Global override for container image registry. |
 | global.nodeSelector | object | `{}` | Node selector for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
 | global.tolerations | list | `[]` | Toleration for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
 
@@ -93,32 +94,46 @@ The `values.yaml` contains items used to tweak a deployment of this chart.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| image.csi.attacher.registry | string | `"docker.io"` | Registry for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.attacher.tag | string | `"v4.8.1"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.registry | string | `"docker.io"` | Registry for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.tag | string | `"v2.15.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.nodeDriverRegistrar.registry | string | `"docker.io"` | Registry for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.tag | string | `"v2.13.0"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
+| image.csi.provisioner.registry | string | `"docker.io"` | Registry for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.tag | string | `"v5.2.0"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
+| image.csi.resizer.registry | string | `"docker.io"` | Registry for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
 | image.csi.resizer.tag | string | `"v1.13.2"` | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
+| image.csi.snapshotter.registry | string | `"docker.io"` | Registry for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
 | image.csi.snapshotter.repository | string | `"longhornio/csi-snapshotter"` | Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
 | image.csi.snapshotter.tag | string | `"v8.2.0"` | Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
+| image.longhorn.backingImageManager.registry | string | `"docker.io"` | Registry for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |
 | image.longhorn.backingImageManager.repository | string | `"longhornio/backing-image-manager"` | Repository for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |
 | image.longhorn.backingImageManager.tag | string | `"v1.9.0"` | Tag for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |
+| image.longhorn.engine.registry | string | `"docker.io"` | Registry for the Longhorn Engine image. |
 | image.longhorn.engine.repository | string | `"longhornio/longhorn-engine"` | Repository for the Longhorn Engine image. |
 | image.longhorn.engine.tag | string | `"v1.9.0"` | Tag for the Longhorn Engine image. |
+| image.longhorn.instanceManager.registry | string | `"docker.io"` | Registry for the Longhorn Instance Manager image. |
 | image.longhorn.instanceManager.repository | string | `"longhornio/longhorn-instance-manager"` | Repository for the Longhorn Instance Manager image. |
 | image.longhorn.instanceManager.tag | string | `"v1.9.0"` | Tag for the Longhorn Instance Manager image. |
+| image.longhorn.manager.registry | string | `"docker.io"` | Registry for the Longhorn Manager image. |
 | image.longhorn.manager.repository | string | `"longhornio/longhorn-manager"` | Repository for the Longhorn Manager image. |
 | image.longhorn.manager.tag | string | `"v1.9.0"` | Tag for the Longhorn Manager image. |
+| image.longhorn.shareManager.registry | string | `"docker.io"` | Registry for the Longhorn Share Manager image. |
 | image.longhorn.shareManager.repository | string | `"longhornio/longhorn-share-manager"` | Repository for the Longhorn Share Manager image. |
 | image.longhorn.shareManager.tag | string | `"v1.9.0"` | Tag for the Longhorn Share Manager image. |
+| image.longhorn.supportBundleKit.registry | string | `"docker.io"` | Registry for the Longhorn Support Bundle Manager image. |
 | image.longhorn.supportBundleKit.repository | string | `"longhornio/support-bundle-kit"` | Repository for the Longhorn Support Bundle Manager image. |
 | image.longhorn.supportBundleKit.tag | string | `"v0.0.55"` | Tag for the Longhorn Support Bundle Manager image. |
+| image.longhorn.ui.registry | string | `"docker.io"` | Registry for the Longhorn UI image. |
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"v1.9.0"` | Tag for the Longhorn UI image. |
+| image.openshift.oauthProxy.registry | string | `"docker.io"` | Registry for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users. |
 | image.openshift.oauthProxy.repository | string | `""` | Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users. |
 | image.openshift.oauthProxy.tag | string | `""` | Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.15, which is available at quay.io/openshift/origin-oauth-proxy:4.15). This setting applies only to OpenShift users. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI. |

--- a/charts/longhorn/templates/_helpers.tpl
+++ b/charts/longhorn/templates/_helpers.tpl
@@ -40,7 +40,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 
 {{- define "system_default_registry" -}}
 {{- if .Values.global.cattle.systemDefaultRegistry -}}
-{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- .Values.global.cattle.systemDefaultRegistry -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}
@@ -48,7 +48,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 
 {{- define "registry_url" -}}
 {{- if .Values.privateRegistry.registryUrl -}}
-{{- printf "%s/" .Values.privateRegistry.registryUrl -}}
+{{- .Values.privateRegistry.registryUrl -}}
 {{- else -}}
 {{ include "system_default_registry" . }}
 {{- end -}}

--- a/charts/longhorn/templates/daemonset-sa.yaml
+++ b/charts/longhorn/templates/daemonset-sa.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: longhorn-manager
-        image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true
@@ -32,17 +32,17 @@ spec:
         {{- end }}
         - daemon
         - --engine-image
-        - "{{ template "registry_url" . }}{{ .Values.image.longhorn.engine.repository }}:{{ .Values.image.longhorn.engine.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.engine.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.engine.repository }}:{{ .Values.image.longhorn.engine.tag }}"
         - --instance-manager-image
-        - "{{ template "registry_url" . }}{{ .Values.image.longhorn.instanceManager.repository }}:{{ .Values.image.longhorn.instanceManager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.instanceManager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.instanceManager.repository }}:{{ .Values.image.longhorn.instanceManager.tag }}"
         - --share-manager-image
-        - "{{ template "registry_url" . }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.shareManager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}"
         - --backing-image-manager-image
-        - "{{ template "registry_url" . }}{{ .Values.image.longhorn.backingImageManager.repository }}:{{ .Values.image.longhorn.backingImageManager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.backingImageManager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.backingImageManager.repository }}:{{ .Values.image.longhorn.backingImageManager.tag }}"
         - --support-bundle-manager-image
-        - "{{ template "registry_url" . }}{{ .Values.image.longhorn.supportBundleKit.repository }}:{{ .Values.image.longhorn.supportBundleKit.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.supportBundleKit.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.supportBundleKit.repository }}:{{ .Values.image.longhorn.supportBundleKit.tag }}"
         - --manager-image
-        - "{{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
+        - "{{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
         - --service-account
         - longhorn-service-account
         {{- if .Values.preUpgradeChecker.upgradeVersionCheck}}
@@ -106,7 +106,7 @@ spec:
         {{- end }}
       - name: pre-pull-share-manager-image
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: {{ template "registry_url" . }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.shareManager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}
         command: ["sh", "-c", "echo share-manager image pulled && sleep infinity"]
       volumes:
       - name: boot

--- a/charts/longhorn/templates/deployment-driver.yaml
+++ b/charts/longhorn/templates/deployment-driver.yaml
@@ -16,11 +16,11 @@ spec:
     spec:
       initContainers:
         - name: wait-longhorn-manager
-          image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+          image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
       containers:
         - name: longhorn-driver-deployer
-          image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+          image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - longhorn-manager
@@ -30,7 +30,7 @@ spec:
           {{- end }}
           - deploy-driver
           - --manager-image
-          - "{{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
+          - "{{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
           - --manager-url
           - http://longhorn-backend:9500/v1
           env:
@@ -52,27 +52,27 @@ spec:
           {{- end }}
           {{- if and .Values.image.csi.attacher.repository .Values.image.csi.attacher.tag }}
           - name: CSI_ATTACHER_IMAGE
-            value: "{{ template "registry_url" . }}{{ .Values.image.csi.attacher.repository }}:{{ .Values.image.csi.attacher.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry .Values.image.csi.attacher.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.csi.attacher.repository }}:{{ .Values.image.csi.attacher.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.provisioner.repository .Values.image.csi.provisioner.tag }}
           - name: CSI_PROVISIONER_IMAGE
-            value: "{{ template "registry_url" . }}{{ .Values.image.csi.provisioner.repository }}:{{ .Values.image.csi.provisioner.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry .Values.image.csi.provisioner.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.csi.provisioner.repository }}:{{ .Values.image.csi.provisioner.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.nodeDriverRegistrar.repository .Values.image.csi.nodeDriverRegistrar.tag }}
           - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "{{ template "registry_url" . }}{{ .Values.image.csi.nodeDriverRegistrar.repository }}:{{ .Values.image.csi.nodeDriverRegistrar.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry .Values.image.csi.nodeDriverRegistrar.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.csi.nodeDriverRegistrar.repository }}:{{ .Values.image.csi.nodeDriverRegistrar.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.resizer.repository .Values.image.csi.resizer.tag }}
           - name: CSI_RESIZER_IMAGE
-            value: "{{ template "registry_url" . }}{{ .Values.image.csi.resizer.repository }}:{{ .Values.image.csi.resizer.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry .Values.image.csi.resizer.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.csi.resizer.repository }}:{{ .Values.image.csi.resizer.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.snapshotter.repository .Values.image.csi.snapshotter.tag }}
           - name: CSI_SNAPSHOTTER_IMAGE
-            value: "{{ template "registry_url" . }}{{ .Values.image.csi.snapshotter.repository }}:{{ .Values.image.csi.snapshotter.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry .Values.image.csi.snapshotter.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.csi.snapshotter.repository }}:{{ .Values.image.csi.snapshotter.tag }}"
           {{- end }}
           {{- if and .Values.image.csi.livenessProbe.repository .Values.image.csi.livenessProbe.tag }}
           - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "{{ template "registry_url" . }}{{ .Values.image.csi.livenessProbe.repository }}:{{ .Values.image.csi.livenessProbe.tag }}"
+            value: "{{ with (coalesce .Values.global.imageRegistry .Values.image.csi.livenessProbe.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.csi.livenessProbe.repository }}:{{ .Values.image.csi.livenessProbe.tag }}"
           {{- end }}
           {{- if .Values.csi.attacherReplicaCount }}
           - name: CSI_ATTACHER_REPLICA_COUNT

--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -61,7 +61,7 @@ spec:
       {{- if .Values.openshift.ui.route }}
       - name: oauth-proxy
         {{- if .Values.image.openshift.oauthProxy.repository }}
-        image: {{ template "registry_url" . }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry .Values.image.openshift.oauthProxy.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
         {{- else }}
         image: ""
         {{- end }}
@@ -84,7 +84,7 @@ spec:
       {{- end }}
       {{- end }}
       - name: longhorn-ui
-        image: {{ template "registry_url" . }}{{ .Values.image.longhorn.ui.repository }}:{{ .Values.image.longhorn.ui.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.ui.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.ui.repository }}:{{ .Values.image.longhorn.ui.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: nginx-cache

--- a/charts/longhorn/templates/postupgrade-job.yaml
+++ b/charts/longhorn/templates/postupgrade-job.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: longhorn-post-upgrade
-        image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - longhorn-manager

--- a/charts/longhorn/templates/preupgrade-job.yaml
+++ b/charts/longhorn/templates/preupgrade-job.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: longhorn-pre-upgrade
-        image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true

--- a/charts/longhorn/templates/uninstall-job.yaml
+++ b/charts/longhorn/templates/uninstall-job.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: longhorn-uninstall
-        image: {{ template "registry_url" . }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        image: {{ with (coalesce .Values.global.imageRegistry .Values.image.longhorn.manager.registry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - longhorn-manager

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 global:
+  # -- Global override for container image registry.
+  imageRegistry: ""
   # -- Toleration for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
   tolerations: []
   # -- Node selector for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
@@ -34,73 +36,101 @@ networkPolicies:
 image:
   longhorn:
     engine:
+      # -- Registry for the Longhorn Engine image.
+      registry: docker.io
       # -- Repository for the Longhorn Engine image.
       repository: longhornio/longhorn-engine
       # -- Tag for the Longhorn Engine image.
       tag: v1.9.0
     manager:
+      # -- Registry for the Longhorn Manager image.
+      registry: docker.io
       # -- Repository for the Longhorn Manager image.
       repository: longhornio/longhorn-manager
       # -- Tag for the Longhorn Manager image.
       tag: v1.9.0
     ui:
+      # -- Registry for the Longhorn UI image.
+      registry: docker.io
       # -- Repository for the Longhorn UI image.
       repository: longhornio/longhorn-ui
       # -- Tag for the Longhorn UI image.
       tag: v1.9.0
     instanceManager:
+      # -- Registry for the Longhorn Instance Manager image.
+      registry: docker.io
       # -- Repository for the Longhorn Instance Manager image.
       repository: longhornio/longhorn-instance-manager
       # -- Tag for the Longhorn Instance Manager image.
       tag: v1.9.0
     shareManager:
+      # -- Registry for the Longhorn Share Manager image.
+      registry: docker.io
       # -- Repository for the Longhorn Share Manager image.
       repository: longhornio/longhorn-share-manager
       # -- Tag for the Longhorn Share Manager image.
       tag: v1.9.0
     backingImageManager:
+      # -- Registry for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
+      registry: docker.io
       # -- Repository for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
       repository: longhornio/backing-image-manager
       # -- Tag for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
       tag: v1.9.0
     supportBundleKit:
+      # -- Registry for the Longhorn Support Bundle Manager image.
+      registry: docker.io
       # -- Repository for the Longhorn Support Bundle Manager image.
       repository: longhornio/support-bundle-kit
       # -- Tag for the Longhorn Support Bundle Manager image.
       tag: v0.0.55
   csi:
     attacher:
+      # -- Registry for the CSI attacher image. When unspecified, Longhorn uses the default value.
+      registry: docker.io
       # -- Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-attacher
       # -- Tag for the CSI attacher image. When unspecified, Longhorn uses the default value.
       tag: v4.8.1
     provisioner:
+      # -- Registry for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
+      registry: docker.io
       # -- Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-provisioner
       # -- Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
       tag: v5.2.0
     nodeDriverRegistrar:
+      # -- Registry for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
+      registry: docker.io
       # -- Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-node-driver-registrar
       # -- Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
       tag: v2.13.0
     resizer:
+      # -- Registry for the CSI Resizer image. When unspecified, Longhorn uses the default value.
+      registry: docker.io
       # -- Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-resizer
       # -- Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value.
       tag: v1.13.2
     snapshotter:
+      # -- Registry for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
+      registry: docker.io
       # -- Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
       repository: longhornio/csi-snapshotter
       # -- Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
       tag: v8.2.0
     livenessProbe:
+      # -- Registry for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
+      registry: docker.io
       # -- Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
       repository: longhornio/livenessprobe
       # -- Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
       tag: v2.15.0
   openshift:
     oauthProxy:
+      # -- Registry for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users.
+      registry: docker.io
       # -- Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users.
       repository: ""
       # -- Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.15, which is available at quay.io/openshift/origin-oauth-proxy:4.15). This setting applies only to OpenShift users.


### PR DESCRIPTION
A big part of the Helm charts have standardized on using `global.imageRegistry` as a way to override the image registry, in addition to per-image modifications via `*.registry` (in the same level as `*.repository`). 

This PR improves the Helm chart to support overriding the container image registry both globally, using the standardized `global.imageRegistry` value, as well as per-image via `$imagePath.registry`.