### PR TITLE
chore: remove preserveUnkwownFields property

### DIFF
--- a/charts/longhorn/templates/crds.yaml
+++ b/charts/longhorn/templates/crds.yaml
@@ -1443,7 +1443,6 @@ spec:
     shortNames:
     - lhei
     singular: engineimage
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -1646,7 +1645,6 @@ spec:
     shortNames:
     - lhe
     singular: engine
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -2045,7 +2043,6 @@ spec:
     shortNames:
     - lhim
     singular: instancemanager
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -2404,7 +2401,6 @@ spec:
     shortNames:
     - lhn
     singular: node
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -2999,7 +2995,6 @@ spec:
     shortNames:
     - lhr
     singular: replica
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -3286,7 +3281,6 @@ spec:
     shortNames:
     - lhs
     singular: setting
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -4194,7 +4188,6 @@ spec:
     shortNames:
     - lhv
     singular: volume
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
As of k8s v1.22, the property `preserveUnknownFields` has been deprecated. For CRDs created with apiextensions API v1, the behavior designated by this property (automatically prune unknown fields) is false, so explicitly setting this property to false is redundant.

The `preserveUnknownFields` property itself can be pruned, causing differences in the desired state from the actual state - although not important, tools like ArgoCD will show the CRDs as being out of sync.

Since all CRDs use apiextension API version v1, and this helm chart only supports k8s v1.25+, it should be safe to remove this property.