### PR TITLE
remove unused longhorn-support-bundle service account

### DIFF
--- a/charts/longhorn/templates/clusterrolebinding.yaml
+++ b/charts/longhorn/templates/clusterrolebinding.yaml
@@ -11,20 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: longhorn-service-account
   namespace: {{ include "release_namespace" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: longhorn-support-bundle
-  labels: {{- include "longhorn.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: longhorn-support-bundle
-  namespace: {{ include "release_namespace" . }}
 {{- if .Values.openshift.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/longhorn/templates/serviceaccount.yaml
+++ b/charts/longhorn/templates/serviceaccount.yaml
@@ -27,14 +27,3 @@ metadata:
     serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"longhorn-ui"}}'
   {{- end }}
   {{- end }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: longhorn-support-bundle
-  namespace: {{ include "release_namespace" . }}
-  labels: {{- include "longhorn.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}


### PR DESCRIPTION
Service account `longhorn-support-bundle` was granted `cluster-admin` role. Based on basic inspection, to me it looks to not be in use but I may be wrong. 

If its really is not in use, it should be removed