### PR TITLE
Add timezone

### DIFF
--- a/charts/longhorn/templates/daemonset-sa.yaml
+++ b/charts/longhorn/templates/daemonset-sa.yaml
@@ -98,6 +98,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: TZ
+          value: {{ .Values.longhornManager.timezone | quote }}
         {{- if .Values.enableGoCoverDir }}
         - name: GOCOVERDIR
           value: /go-cover-dir/

--- a/charts/longhorn/templates/daemonset-sa.yaml
+++ b/charts/longhorn/templates/daemonset-sa.yaml
@@ -98,8 +98,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        {{- if .Values.longhornManager.timezone }}
         - name: TZ
           value: {{ .Values.longhornManager.timezone | quote }}
+        {{- end }}
         {{- if .Values.enableGoCoverDir }}
         - name: GOCOVERDIR
           value: /go-cover-dir/

--- a/charts/longhorn/templates/deployment-driver.yaml
+++ b/charts/longhorn/templates/deployment-driver.yaml
@@ -46,6 +46,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
+          - name: TZ
+            value: {{ .Values.longhornManager.timezone | quote }}
           {{- if .Values.csi.kubeletRootDir }}
           - name: KUBELET_ROOT_DIR
             value: {{ .Values.csi.kubeletRootDir }}

--- a/charts/longhorn/templates/deployment-driver.yaml
+++ b/charts/longhorn/templates/deployment-driver.yaml
@@ -46,8 +46,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
+          {{- if .Values.longhornManager.timezone }}
           - name: TZ
             value: {{ .Values.longhornManager.timezone | quote }}
+          {{- end }}
           {{- if .Values.csi.kubeletRootDir }}
           - name: KUBELET_ROOT_DIR
             value: {{ .Values.csi.kubeletRootDir }}

--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -101,6 +101,8 @@ spec:
             value: "http://longhorn-backend:9500"
           - name: LONGHORN_UI_PORT
             value: "8000"
+          - name: TZ
+            value: {{ .Values.longhornManager.timezone | quote }}
       volumes:
       {{- if .Values.openshift.enabled }}
       {{- if .Values.openshift.ui.route }}

--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -101,8 +101,10 @@ spec:
             value: "http://longhorn-backend:9500"
           - name: LONGHORN_UI_PORT
             value: "8000"
+          {{- if .Values.longhornManager.timezone }}
           - name: TZ
             value: {{ .Values.longhornManager.timezone | quote }}
+          {{- end }}
       volumes:
       {{- if .Values.openshift.enabled }}
       {{- if .Values.openshift.ui.route }}

--- a/charts/longhorn/templates/postupgrade-job.yaml
+++ b/charts/longhorn/templates/postupgrade-job.yaml
@@ -27,8 +27,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.longhornManager.timezone }}
         - name: TZ
           value: {{ .Values.longhornManager.timezone | quote }}
+        {{- end }}
       restartPolicy: OnFailure
       {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:

--- a/charts/longhorn/templates/postupgrade-job.yaml
+++ b/charts/longhorn/templates/postupgrade-job.yaml
@@ -27,6 +27,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: TZ
+          value: {{ .Values.longhornManager.timezone | quote }}
       restartPolicy: OnFailure
       {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:

--- a/charts/longhorn/templates/preupgrade-job.yaml
+++ b/charts/longhorn/templates/preupgrade-job.yaml
@@ -33,8 +33,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.longhornManager.timezone }}
         - name: TZ
           value: {{ .Values.longhornManager.timezone | quote }}
+        {{- end }}
       volumes:
       - name: proc
         hostPath:

--- a/charts/longhorn/templates/preupgrade-job.yaml
+++ b/charts/longhorn/templates/preupgrade-job.yaml
@@ -33,6 +33,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: TZ
+          value: {{ .Values.longhornManager.timezone | quote }}
       volumes:
       - name: proc
         hostPath:

--- a/charts/longhorn/templates/uninstall-job.yaml
+++ b/charts/longhorn/templates/uninstall-job.yaml
@@ -28,8 +28,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.longhornManager.timezone }}
         - name: TZ
           value: {{ .Values.longhornManager.timezone | quote }}
+        {{- end }}
       restartPolicy: Never
       {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:

--- a/charts/longhorn/templates/uninstall-job.yaml
+++ b/charts/longhorn/templates/uninstall-job.yaml
@@ -28,6 +28,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: TZ
+          value: {{ .Values.longhornManager.timezone | quote }}
       restartPolicy: Never
       {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
       imagePullSecrets:

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -419,7 +419,9 @@ longhornManager:
   log:
     # -- Format of Longhorn Manager logs. (Options: "plain", "json")
     format: plain
-  timezone: UTC
+  ## Timezone for Longhorn Manager. (Options: null (use the node's timezone), "UTC", or any IANA Time Zone database name such as "America/New_York", "Asia/Tokyo", "Europe/Berlin")
+  ## This affects the time shown in the Longhorn UI and the timezone used on the time for cronjob if you set any cronjob based settings.
+  timezone: ~
   # -- PriorityClass for Longhorn Manager.
   priorityClass: *defaultPriorityClassNameRef
   # -- Toleration for Longhorn Manager on nodes allowed to run Longhorn components.

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -419,6 +419,7 @@ longhornManager:
   log:
     # -- Format of Longhorn Manager logs. (Options: "plain", "json")
     format: plain
+  timezone: UTC
   # -- PriorityClass for Longhorn Manager.
   priorityClass: *defaultPriorityClassNameRef
   # -- Toleration for Longhorn Manager on nodes allowed to run Longhorn components.


### PR DESCRIPTION
The log output time and job cron expressions depend on the time zone. For example, `0 0 * * *` will run 9 hours later in Japan, where I live. This change adds the TZ environment variable.