### PR TITLE
Set default registry to docker.io

### DIFF
--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 global:
   # -- Global override for container image registry.
-  imageRegistry: ""
+  imageRegistry: "docker.io"
   # -- Global override for image pull secrets for container registry.
   imagePullSecrets: []
   # -- Toleration for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.


### PR DESCRIPTION
This is mostly a reference solution for https://github.com/longhorn/longhorn/issues/12268 -- fix longhorn image pull failing on K8S/CRI-O 1.34
You might prefer changing this a different way, but this *should* serve as a fix for now