### PR TITLE
feat: add loadBalancerClass for ui service to values

### DIFF
--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -179,6 +179,9 @@ spec:
   {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.service.ui.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.ui.loadBalancerClass }}
+  {{- end }}
   selector:
     app: longhorn-ui
   ports:

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -145,6 +145,8 @@ service:
     type: ClusterIP
     # -- NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767.
     nodePort: null
+    # -- Class of a load balancer implementation
+    loadBalancerClass: ""
     # -- Annotation for the Longhorn UI service.
     annotations: {}
     ## If you want to set annotations for the Longhorn UI service, delete the `{}` in the line above


### PR DESCRIPTION
Allow setting loadBalancerClass. It is useful for example for Tailscale operator ingress.