### PR TITLE
Fix indentation in ui-frontend-network-policy.yaml

### DIFF
--- a/charts/longhorn/templates/network-policies/ui-frontend-network-policy.yaml
+++ b/charts/longhorn/templates/network-policies/ui-frontend-network-policy.yaml
@@ -37,10 +37,10 @@ spec:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: traefik
+    {{- end }}
     ports:
       - port: 8000
         protocol: TCP
       - port: 80
         protocol: TCP
-    {{- end }}
 {{- end }}


### PR DESCRIPTION
This changes fixes a bug where only the k3s type works. rke1 and rke2 d not have ports selected.