### PR TITLE
fix: default to 50% max unavailable for longhorn manager daemonset

### DIFF
--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -485,7 +485,7 @@ longhornManager:
   ## if you prefer that behavior.
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: "100%"
+      maxUnavailable: "50%"
 longhornDriver:
   log:
     # -- Format of longhorn-driver logs. (Options: "plain", "json")


### PR DESCRIPTION
When using 100% max unavailable for the longhorn-manager daemonset a helm upgrade fails with the following error.

```
 Upgrade failed: an error occurred while rolling back the release. original
│ upgrade error: failed to create resource: Internal error occurred: failed
│ calling webhook "mutator.longhorn.io": failed to call webhook: Post
│ "https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/webhook/mutation?timeout=10s":
│ no endpoints available for service "longhorn-admission-webhook": failed to
│ create resource: Internal error occurred: failed calling webhook
│ "mutator.longhorn.io": failed to call webhook: Post
│ "https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/webhook/mutation?timeout=10s":
│ no endpoints available for service "longhorn-admission-webhook"
```

This can be fixed by setting max unavailable lower than 100%.