### PR TITLE
fix: properly resolve `registry` value when installing on openshift

### DIFF
--- a/charts/longhorn/templates/deployment-ui.yaml
+++ b/charts/longhorn/templates/deployment-ui.yaml
@@ -61,7 +61,7 @@ spec:
       {{- if .Values.openshift.ui.route }}
       - name: oauth-proxy
         {{- if .Values.image.openshift.oauthProxy.repository }}
-        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.openshift.oauthProxy.registry) }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
+        image: {{ with (coalesce .Values.image.openshift.oauthProxy.registry .Values.global.imageRegistry (include "registry_url" .)) }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
         {{- else }}
         image: ""
         {{- end }}


### PR DESCRIPTION
fix for: https://github.com/longhorn/longhorn/issues/12685

```
helm template longhorn ./longhorn-charts/charts/longhorn \
  --set openshift.enabled=true \
  --set openshift.ui.route=longhorn-ui \
  --set image.openshift.oauthProxy.registry=quay.io \
  --set image.openshift.oauthProxy.repository=openshift/origin-oauth-proxy \
  --set image.openshift.oauthProxy.tag=4.18 \
  | grep -A1 "oauth-proxy" | grep image
        image: quay.io/openshift/origin-oauth-proxy:4.18
        imagePullPolicy: IfNotPresent
```