### PR TITLE
feat(setting) #4542: add staleReplicaTimeout to default settings

### DIFF
--- a/charts/longhorn/templates/default-setting.yaml
+++ b/charts/longhorn/templates/default-setting.yaml
@@ -125,6 +125,9 @@ data:
     {{- if not (kindIs "invalid" .Values.defaultSettings.replicaReplenishmentWaitInterval) }}
     replica-replenishment-wait-interval: {{ .Values.defaultSettings.replicaReplenishmentWaitInterval | quote }}
     {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.staleReplicaTimeout) }}
+    stale-replica-timeout: {{ .Values.defaultSettings.staleReplicaTimeout | quote }}
+    {{- end }}
     {{- if not (kindIs "invalid" .Values.defaultSettings.concurrentReplicaRebuildPerNodeLimit) }}
     concurrent-replica-rebuild-per-node-limit: {{ .Values.defaultSettings.concurrentReplicaRebuildPerNodeLimit | quote }}
     {{- end }}

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -316,6 +316,9 @@ defaultSettings:
   detachManuallyAttachedVolumesWhenCordoned: ~
   # -- Number of seconds that Longhorn waits before reusing existing data on a failed replica instead of creating a new replica of a degraded volume.
   replicaReplenishmentWaitInterval: ~
+  # -- Number of minutes that Longhorn waits before cleaning up a stale replica that is no longer part of the volume engine.
+  # Setting this to 0 will cause the stale replicas to be cleaned up immediately. The default value is "2880" (48 hours).
+  staleReplicaTimeout: ~
   # -- Maximum number of replicas that can be concurrently rebuilt on each node.
   concurrentReplicaRebuildPerNodeLimit: ~
   # -- Maximum number of file synchronization operations that can run concurrently during a single replica rebuild. Right now, it's for v1 data engine only.


### PR DESCRIPTION
The `staleReplicaTimeout` was previously hardcoded in the codebase (defaulting to 2880 minutes) and could not be configured globally or at the time of Helm installation/upgrade.

This PR adds `staleReplicaTimeout` to the `defaultSettings` in the Longhorn Helm chart. This allows users to:

1. Define a global default for all volumes during initial installation.
2. Update the global default during a chart upgrade.

This change works in tandem with the logic implemented in the `longhorn-manager` PR (linked below), which introduces the fallback mechanism and respects the `replicaReplenishmentWaitInterval`.

### Related Issue and PR

* [Related PR](https://github.com/longhorn/longhorn-manager/pull/4661)
* [Related Issue](https://github.com/longhorn/longhorn/issues/4542)

### Changes

- **values.yaml**: Added `staleReplicaTimeout` key under `defaultSettings` with documentation.
- **templates/default-setting.yaml**: Added logic to include `stale-replica-timeout` in the `longhorn-default-setting` ConfigMap.