### PR TITLE
Render the pre-upgrade job only on upgrades

### DIFF
--- a/charts/longhorn/templates/preupgrade-job.yaml
+++ b/charts/longhorn/templates/preupgrade-job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.preUpgradeChecker.jobEnabled .Values.preUpgradeChecker.upgradeVersionCheck}}
+{{- if and .Values.preUpgradeChecker.jobEnabled .Values.preUpgradeChecker.upgradeVersionCheck .Release.IsUpgrade}}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
## Problem

`templates/preupgrade-job.yaml` is annotated `helm.sh/hook: pre-upgrade`, so
plain Helm skips it on a fresh install. Argo CD maps `pre-upgrade` to its
`PreSync` phase and runs it on **every** sync, including the first one.

The job runs as `serviceAccountName: longhorn-service-account`, which this same
chart ships as a regular resource — and PreSync hooks run before regular
resources exist:

```
Error creating: pods "longhorn-pre-upgrade-" is forbidden:
  error looking up service account longhorn-system/longhorn-service-account:
  serviceaccount "longhorn-service-account" not found
```

The job never gets a pod, hits `activeDeadlineSeconds: 900`, Argo retries, and
the Application stays `OutOfSync/Missing` indefinitely. Nothing else from the
chart installs: no `longhorn-rwx` StorageClass, PVCs stay `Pending`, workloads
never schedule.

It is also hard to diagnose. While pods sit unschedulable, the cluster
autoscaler logs `pod didn't trigger scale-up` and later `max node group size
reached`, which points the investigation at capacity instead of at a stuck
hook.

## Change

One condition:

```diff
-{{- if and .Values.preUpgradeChecker.jobEnabled .Values.preUpgradeChecker.upgradeVersionCheck}}
+{{- if and .Values.preUpgradeChecker.jobEnabled .Values.preUpgradeChecker.upgradeVersionCheck .Release.IsUpgrade}}
```

This matches what the hook is for — a pre-upgrade version check has nothing to
check when there is no previous release. **Plain Helm behaviour is unchanged**,
because the `pre-upgrade` hook was already skipped on install.

## Verified against 1.12.1-rc2

```
helm template lh charts/longhorn -n longhorn-system
  -> no longhorn-pre-upgrade

helm template lh charts/longhorn -n longhorn-system --is-upgrade
  -> longhorn-pre-upgrade rendered
```

## Note

`values.yaml` already tells GitOps users to set
`preUpgradeChecker.jobEnabled: false`, but that is an opt-out buried in a
comment — the default still breaks every first install under Argo CD. Happy to
adjust the approach if you would rather solve it by shipping the service
account as an earlier hook instead.