### PR TITLE
Fail when the moved backup store values are still set

### DIFF
--- a/charts/longhorn/templates/validate-moved-values.yaml
+++ b/charts/longhorn/templates/validate-moved-values.yaml
@@ -1,0 +1,15 @@
+{{- /*
+The backup store settings moved from defaultSettings to defaultBackupStore in
+v1.8.0. Helm drops unknown values without a word, so a values file still using
+the old keys renders and installs cleanly - with no backup target configured.
+Fail instead, and name the replacement.
+*/ -}}
+{{- if not (kindIs "invalid" .Values.defaultSettings.backupTarget) }}
+{{- fail "defaultSettings.backupTarget moved to defaultBackupStore.backupTarget in v1.8.0. The value under defaultSettings has no effect." }}
+{{- end }}
+{{- if not (kindIs "invalid" .Values.defaultSettings.backupTargetCredentialSecret) }}
+{{- fail "defaultSettings.backupTargetCredentialSecret moved to defaultBackupStore.backupTargetCredentialSecret in v1.8.0. The value under defaultSettings has no effect." }}
+{{- end }}
+{{- if not (kindIs "invalid" .Values.defaultSettings.backupstorePollInterval) }}
+{{- fail "defaultSettings.backupstorePollInterval moved to defaultBackupStore.pollInterval in v1.8.0. The value under defaultSettings has no effect." }}
+{{- end }}


### PR DESCRIPTION
## Problem

The backup store settings moved from `defaultSettings` to `defaultBackupStore`
in v1.8.0 (`d5f9fd8`). Helm drops unknown values silently, so a values file
still using the old keys renders and installs cleanly — and the cluster ends up
with no backup target:

```
backuptarget/default:  backupTargetURL: ""   available: false
                       "backup target URL is empty"
```

Nothing fails along the way. Under Argo CD every resource reports
`Synced/Healthy`, the Longhorn UI looks normal, and RecurringJobs run against a
target that does not exist. An environment can pass as complete while its
backups go nowhere.

We only caught it because our smoke test checks `backuptarget/default`
`status.available` instead of the configuration — otherwise it would have
stayed hidden until a restore was needed.

## Change

A template that fails the render when any of the three moved keys is set, and
names the replacement:

- `defaultSettings.backupTarget` → `defaultBackupStore.backupTarget`
- `defaultSettings.backupTargetCredentialSecret` → `defaultBackupStore.backupTargetCredentialSecret`
- `defaultSettings.backupstorePollInterval` → `defaultBackupStore.pollInterval`

This follows the pattern the chart already uses in
`templates/registry-secret.yaml` for `privateRegistry.registrySecret`.

## Verified against 1.12.1-rc2

```
helm template lh charts/longhorn -n longhorn-system
  -> renders

helm template lh charts/longhorn -n longhorn-system \
  --set defaultSettings.backupTarget=s3://bucket@eu01/
  -> Error: defaultSettings.backupTarget moved to
     defaultBackupStore.backupTarget in v1.8.0. The value under
     defaultSettings has no effect.

helm template lh charts/longhorn -n longhorn-system \
  --set defaultBackupStore.backupTarget=s3://bucket@eu01/
  -> backup-target: s3://bucket@eu01/
```

## Note

This is deliberately a hard failure rather than a warning: a silently ignored
backup target is worse than a render that stops and tells you which key to
change. If you would prefer a deprecation warning for a release or two first,
I am happy to change it.